### PR TITLE
Removing symbols; See websharks/comment-mail#132

### DIFF
--- a/comment-mail/readme.txt
+++ b/comment-mail/readme.txt
@@ -1,4 +1,4 @@
-=== Comment Mail™ (WP Comment Subscriptions) ===
+=== Comment Mail (WP Comment Subscriptions) ===
 
 Stable tag: 150709
 Requires at least: 4.0
@@ -12,7 +12,7 @@ Contributors: WebSharks, JasWSInc, raamdev, kristineds, reedyseth, sitegeek
 Donate link: http://www.websharks-inc.com/r/wp-theme-plugin-donation/
 Tags: comments, subscribe, comment subscription, comment subscriptions, comment subscribe, subscribe comments, comment, comment email, comment notification, notifications, notification
 
-Email comment subscriptions for WordPress®
+Email comment subscriptions for WordPress
 
 == Description ==
 


### PR DESCRIPTION
Remove [™ (trademark) symbol](https://github.com/websharks/comment-mail/blob/150709/comment-mail/readme.txt#L1) from WordPress.org Plugin Name and [® symbol](https://github.com/websharks/comment-mail/blob/150709/comment-mail/readme.txt#L15) from WordPress name

See websharks/comment-mail#132