### PR TITLE
Fix spelling mistake in email template; See: websharks/comment-mail#208

### DIFF
--- a/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -8,12 +8,12 @@
 
 	[if sub_comment]
 		[if subscribed_to_own_comment]
-			You are receiving this email because asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
+			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-	        You are receiving this email because asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+	        You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
-		You are receiving this email because asked to be notified about all comments/replies to:
+		You are receiving this email because you asked to be notified about all comments/replies to:
 	[endif]
 
 </p>

--- a/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -10,7 +10,7 @@
 		[if subscribed_to_own_comment]
 			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-	        You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+	    You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
 		You are receiving this email because you asked to be notified about all comments/replies to:

--- a/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -10,7 +10,7 @@
 		[if subscribed_to_own_comment]
 			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
+			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
 		You are receiving this email because you asked to be notified about all comments/replies to:

--- a/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -10,7 +10,7 @@
 		[if subscribed_to_own_comment]
 			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-	    You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+      You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
 		[endif]
 	[else]
 		You are receiving this email because you asked to be notified about all comments/replies to:

--- a/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
+++ b/comment-mail/includes/templates/type-s/email/sub-confirmation/snippet/message.php
@@ -10,7 +10,7 @@
 		[if subscribed_to_own_comment]
 			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[else]
-      You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">this comment</a>; on:
+			You are receiving this email because you asked to be notified about replies to <a href="[sub_comment_url]">your comment</a>; on:
 		[endif]
 	[else]
 		You are receiving this email because you asked to be notified about all comments/replies to:


### PR DESCRIPTION
Fix spelling mistake in email template; 

- If selected, "yes, replies to my comment"
![screen shot 2016-01-22 at 5 53 41 pm](https://cloud.githubusercontent.com/assets/7514953/12507648/fe63b414-c131-11e5-9015-f0c7cb728dcd.png)


- If selected, "yes, all comments/replies"
![screen shot 2016-01-22 at 5 56 25 pm](https://cloud.githubusercontent.com/assets/7514953/12507654/17a1b552-c132-11e5-8b41-6a49a7c30038.png)

See: websharks/comment-mail#208